### PR TITLE
Fix typo #662 in espanso docs

### DIFF
--- a/versioned_docs/version-0.7.3/matches.md
+++ b/versioned_docs/version-0.7.3/matches.md
@@ -555,7 +555,7 @@ You can use this feature by declaring a variable of type `random` and then passi
 ```
 
 
-In this case, typing `:quote` will expand randomly to one of the tree quotes.
+In this case, typing `:quote` will expand randomly to one of the three quotes.
 
 ### Clipboard Extension
 


### PR DESCRIPTION
Typo found from issue: https://github.com/federico-terzi/espanso/issues/662
Doc link: https://espanso.org/docs/matches/

Details:
> before: the tree quotes
> after: the three quotes